### PR TITLE
openapi-generatorのバージョンを5.4.0から6.2.1に更新

### DIFF
--- a/openapitools.json
+++ b/openapitools.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "5.4.0"
+    "version": "6.2.1"
   }
 }


### PR DESCRIPTION
openapi-generatorのアップデート前後で生成結果に変化はなかった．
問題がある場合は各リポジトリで調整する．