### PR TITLE
Linterのルール修正

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,8 @@
 [flake8]
 max-line-length = 120
-extend-ignore = E203
+extend-ignore =
+  # E203: Whitespace before ':'
+  E203,
+  # P123: open("foo") should be replaced by Path("foo").open()
+  PL123
 max-complexity = 10

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,22 @@
-[MASTER]
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
 
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
@@ -16,27 +34,40 @@ extension-pkg-whitelist=
 # specified are enabled, while categories only check already-enabled messages.
 fail-on=
 
-# Specify a score threshold to be exceeded before program exits with error.
+# Specify a score threshold under which the program will exit with error.
 fail-under=10.0
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
 
 # Files or directories to be skipped. They should be base names, not paths.
 ignore=CVS
 
-# Add files or directories matching the regex patterns to the ignore-list. The
-# regex matches against paths and can be in Posix or Windows format.
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\' represents the directory delimiter on Windows systems, it
+# can't be used as an escape character.
 ignore-paths=
 
-# Files or directories matching the regex patterns are skipped. The regex
-# matches against base names, not paths. The default value ignores emacs file
-# locks
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
 ignore-patterns=^\.#
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-#init-hook=
+init-hook="./src"
 
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
-# number of processors available to use.
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
 jobs=1
 
 # Control the amount of potential inferred values when inferring a single
@@ -66,6 +97,9 @@ suggestion-mode=yes
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
 
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
+
 
 [MESSAGES CONTROL]
 
@@ -90,13 +124,29 @@ disable=raw-checker-failed,
         suppressed-message,
         useless-suppression,
         deprecated-pragma,
-        use-symbolic-message-instead
+        use-symbolic-message-instead,
+
+        # docstring は必要な場合のみ書けばよいので無効．
+        missing-module-docstring,
+        missing-class-docstring,
+        missing-function-docstring,
+        
+        # flake8(E501) と重複するので無効
+        line-too-long
+
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
 enable=c-extension-no-member
+
+
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
 
 
 [REPORTS]
@@ -339,7 +389,8 @@ additional-builtins=
 allow-global-unused-variables=yes
 
 # List of names allowed to shadow builtins
-allowed-redefined-builtins=
+allowed-redefined-builtins=id,
+                           input
 
 # List of strings which can identify a callback function by name. A callback
 # name must start or end with one of those strings.
@@ -350,8 +401,7 @@ callbacks=cb_,
 # not be used).
 dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
 
-# Argument names that match this expression will be ignored. Default to name
-# with leading underscore.
+# Argument names that match this expression will be ignored.
 ignored-argument-names=_.*|^ignored_|^unused_
 
 # Tells whether we should check for unused import in __init__ files.
@@ -374,10 +424,6 @@ contextmanager-decorators=contextlib.contextmanager
 # expressions are accepted.
 generated-members=numpy.*, torch.*
 
-# Tells whether missing members accessed in mixin class should be ignored. A
-# class is considered mixin if its name matches the mixin-class-rgx option.
-ignore-mixin-members=yes
-
 # Tells whether to warn about missing members when the owner of the attribute
 # is inferred to be None.
 ignore-none=yes
@@ -390,16 +436,16 @@ ignore-none=yes
 # the rest of the inferred objects.
 ignore-on-opaque-inference=yes
 
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of
 # qualified names.
 ignored-classes=optparse.Values,thread._local,_thread._local
-
-# List of module names for which member attributes should not be checked
-# (useful for modules/projects where namespaces are manipulated during runtime
-# and thus existing member attributes cannot be deduced by static analysis). It
-# supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.
@@ -413,8 +459,7 @@ missing-member-hint-distance=1
 # showing a hint for a missing member.
 missing-member-max-choices=1
 
-# Regex pattern to define which classes are considered mixins ignore-mixin-
-# members is set to 'yes'
+# Regex pattern to define which classes are considered mixins.
 mixin-class-rgx=.*[Mm]ixin
 
 # List of decorators that change the signature of a decorated function.
@@ -545,11 +590,6 @@ allow-any-import-level=
 # Allow wildcard imports from modules that define __all__.
 allow-wildcard-with-all=no
 
-# Analyse import fallback blocks. This can be used to support both Python 2 and
-# 3 compatible code, which means that the block might have code that exists
-# only in one or another interpreter, leading to false positives when analysed.
-analyse-fallback-blocks=no
-
 # Deprecated modules which should not be used, separated by a comma.
 deprecated-modules=
 
@@ -579,7 +619,6 @@ preferred-modules=
 
 [EXCEPTIONS]
 
-# Exceptions that will emit a warning when being caught. Defaults to
-# "BaseException, Exception".
+# Exceptions that will emit a warning when caught.
 overgeneral-exceptions=BaseException,
                        Exception

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,12 +17,8 @@ flake8-absolute-import
 flake8-bugbear
 flake8-class-attributes-order
 flake8-comprehensions
-flake8-functions-names
 flake8-implicit-str-concat
-flake8-return
-flake8-use-fstring
 flake8-use-pathlib
-flake8-variables-names
 isort
 mypy
 pep8-naming


### PR DESCRIPTION
- ルール追加はなし
- flake8-functions-names, flake8-return, flake8-use-fstring, flake8-variables-namesは使い勝手が悪い，メンテナンスされていない，他のツールと被る等の理由で削除
- PL123 のルールを無効化
  - 既存のコードは組み込みのopenを使ってるものが多いため
- pylintの一部ルールを無効化
  - https://github.com/besna-institute/python_template/compare/fix-linter?expand=1#diff-ba293004ae8f18975051e825bd8d5c70137a8b5d42d16e0f7c9354aa634c446cR129-R135
- idとinputはPythonの組み込み関数だが，よく使う変数名なので再定義してもエラーがでないようにした
  - https://github.com/besna-institute/python_template/compare/fix-linter?expand=1#diff-ba293004ae8f18975051e825bd8d5c70137a8b5d42d16e0f7c9354aa634c446cR392-R393