### PR TITLE
Pylintのimport-errorの無効化

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -131,8 +131,11 @@ disable=raw-checker-failed,
         missing-class-docstring,
         missing-function-docstring,
         
-        # flake8(E501) と重複するので無効
-        line-too-long
+        # flake8(E501) と重複するので無効．
+        line-too-long,
+
+        # エディタ・IDEでチェックすればいいので無効．
+        import-error
 
 
 # Enable the message, report, category or checker with the given id(s). You can


### PR DESCRIPTION
Pylintでチェックする内容ではない，問題の対処が面倒なので無効