### PR TITLE
JSON Linesのサポート

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,17 @@ functions-framework --target=example --debug
 
 http://localhost:8080 に対してリクエストを送ることができるようになる．
 
+JSON
 ```bash
 curl -X POST -H "Content-Type: application/json" localhost:8080 -d '{"api_name": "Solver", "name": "Taro"}'
 ```
+
+JSON Lines
+```bash
+DATA='{"api_name": "Solver", "name": "Taro"}
+{"api_name": "Solver", "name": "Jiro"}
+{"api_name": "Solver", "name": "Siro"}'
+curl -X POST -H "Content-Type: application/jsonl" localhost:8080 -d "$DATA"
 
 ### ローカルでのテストの実行
 

--- a/tests/example/data/input.jsonl
+++ b/tests/example/data/input.jsonl
@@ -1,2 +1,3 @@
-{"api_name": "Solver","name": "Taro"}
-{"api_name": "Solver","name": "Jiro"}
+{"api_name": "Solver", "name": "Taro"}
+{"api_name": "Solver", "name": "Jiro"}
+{"api_name": "Solver", "name": "Siro"}

--- a/tests/example/data/output.jsonl
+++ b/tests/example/data/output.jsonl
@@ -1,2 +1,3 @@
-{"api_name": "Solver","api_version": "1.0.0","text": "Hello, Taro"}
-{"api_name": "Solver","api_version": "1.0.0","text": "Hello, Jiro"}
+{"api_name": "Solver", "api_version": "1.0.0", "text": "Hello, Taro"}
+{"api_name": "Solver", "api_version": "1.0.0", "text": "Hello, Jiro"}
+{"api_name": "Solver", "api_version": "1.0.0", "text": "Hello, Siro"}

--- a/tests/example/test_entrypoint.py
+++ b/tests/example/test_entrypoint.py
@@ -39,7 +39,7 @@ class EntrypointTest(unittest.TestCase):
         cls._process.kill()
         cls._process.wait()
 
-    def test_input1(self) -> None:
+    def test_json_input(self) -> None:
         """JSONを使ったテスト
         test_with_jsonlと選択。
         """
@@ -53,9 +53,9 @@ class EntrypointTest(unittest.TestCase):
         self.assertEqual(res.status_code, 200)
         self.assertEqual(json.loads(res.text), json_output1)
 
-    def test_with_jsonl(self) -> None:
+    def test_json_input_with_jsonl(self) -> None:
         """JSON Linesを使ったテスト
-        test_input1と選択。
+        test_json_inputと選択。
         """
         with open(path_to_data / "input.jsonl", encoding="utf-8") as input_jsonl, open(
             path_to_data / "output.jsonl", encoding="utf-8"
@@ -66,3 +66,14 @@ class EntrypointTest(unittest.TestCase):
                 res: Response = self.session.post(self.base_url, json=input)
                 self.assertEqual(res.status_code, 200)
                 self.assertEqual(json.loads(res.text), output)
+
+    def test_jsonlines_input(self) -> None:
+        """JSON Linesを入力とするテスト"""
+        with open(path_to_data / "input.jsonl", encoding="utf-8") as input_jsonl, open(
+            path_to_data / "output.jsonl", encoding="utf-8"
+        ) as output_jsonl:
+            input = input_jsonl.read()
+            output = output_jsonl.read()
+            res: Response = self.session.post(self.base_url, data=input, headers={"Content-Type": "application/jsonl"})
+            self.assertEqual(res.status_code, 200)
+            self.assertEqual(res.text, output)


### PR DESCRIPTION
`Content-Type: application/jsonl` と指定された場合JSON Linesとして処理する。
`\n` でエスケープされた文字列を渡すとエラーになるので注意。（直せば解釈できる？）