### PR TITLE
Pylint関連の設定の修正

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,13 @@
     "python.linting.flake8Enabled": true,
     "python.linting.flake8Path": "/home/vscode/.local/bin/flake8",
     "python.linting.mypyEnabled": true,
-    "python.linting.mypyPath": "/home/vscode/.local/bin/mypy"
+    "python.linting.mypyPath": "/home/vscode/.local/bin/mypy",
+    "python.linting.pylintEnabled": true,
+    "python.linting.pylintPath": "/home/vscode/.local/bin/pylint",
+    "python.linting.pylintArgs": [
+      "--enable-all-extensions"
+    ],
+    "python.linting.pylintCategorySeverity.refactor": "Information"
   },
   "extensions": [
     "editorconfig.editorconfig",

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: "3.10"
       - name: Install dependencies
         run: pip install -r requirements.txt
-      - run: python -m pylint src tests *.py --recursive=y --enable-all-extensions
+      - run: python -m pylint src/* tests/* *.py --recursive=y --enable-all-extensions
   flake8:
     runs-on: ubuntu-latest
     steps:

--- a/.pylintrc
+++ b/.pylintrc
@@ -139,7 +139,10 @@ disable=raw-checker-failed,
 
         # メリットが少なく，指摘されるストレスが大きいため無効.
         # https://pylint.pycqa.org/en/latest/user_guide/checkers/features.html#design-checker
-        design
+        design,
+
+        # 「不等式は<に統一し，>は使わない」という慣習と衝突するため無効.
+        misplaced-comparison-constant
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/src/example/entrypoint.py
+++ b/src/example/entrypoint.py
@@ -1,5 +1,4 @@
 import json
-from typing import Any
 
 import functions_framework  # type: ignore
 from flask import jsonify
@@ -23,15 +22,14 @@ def example(request: Request) -> Response:
         jsonl_request_body: str = request.get_data(as_text=True)
         result: list[str] = []
         for json_str in jsonl_request_body.splitlines():
-            if json_str == "":
+            if not json_str:
                 continue
             request_json = json.loads(json_str)
             input_: Input = Input(api_name=request_json["api_name"], name=request_json["name"])
             output_: Output = SomeSolver().process(input=input_)
             result.append(json.dumps(output_.to_dict()))
         return Response("\n".join(result), headers={"Content-Type": "application/jsonl"})
-    request_body: Any | None = request.get_json()
-    if request_body is None:
+    if (request_body := request.get_json()) is None:
         raise ValueError("Invalid JSON.")
     input: Input = Input(api_name=request_body["api_name"], name=request_body["name"])
     output: Output = SomeSolver().process(input=input)

--- a/src/example/solvers.py
+++ b/src/example/solvers.py
@@ -12,7 +12,7 @@ class SomeSolver:
     def __init__(self, api_name: str = "Solver") -> None:
         self.api_name = api_name
 
-    def analyze(self, name: str) -> Result:
+    def analyze(self, name: str) -> Result:  # pylint: disable=no-self-use
         text: str = f"Hello, {name}"
         return Result(text=text)
 

--- a/src/save_result/entrypoint.py
+++ b/src/save_result/entrypoint.py
@@ -1,5 +1,4 @@
 import json
-from typing import Any
 
 import functions_framework  # type: ignore
 from flask.wrappers import Request, Response
@@ -8,8 +7,7 @@ from google.cloud.storage import Client  # type: ignore
 
 @functions_framework.http  # type: ignore
 def save_result(request: Request) -> Response:
-    request_body: Any | None = request.get_json()
-    if request_body is None:
+    if (request_body := request.get_json()) is None:
         raise ValueError("Invalid JSON.")
     print(request_body)
     response_data = json.dumps(request_body["result"])


### PR DESCRIPTION
- コーディング慣習と衝突するmisplaced-comparison-constant の無効化
  - [不等式は<に統一し，>は使わない](https://www.notion.so/be613d7ba8c54118a9ce67a03c1cdf9b)
- VSCodeのPylintの設定を追加
- CIのPylintの対象となるファイルの修正