### PR TITLE
python_templateの更新を適用するactionを追加

### DIFF
--- a/.github/scripts/checkForUpdates.js
+++ b/.github/scripts/checkForUpdates.js
@@ -1,0 +1,38 @@
+const { compareVersions } = require('compare-versions')
+const CURRENT_VERSION = require('./currentVersion.js')
+
+module.exports = async ({ github, context }) => {
+  const tag = await github.rest.repos.listTags({
+    owner: 'besna-institute',
+    repo: 'python_template',
+  }).then(result => result.data[0].name)
+
+  if (context.repo.owner === 'besna-institute' && context.repo.repo === 'python_template' && compareVersions(tag, CURRENT_VERSION, '=')) {
+    return github.rest.issues.create({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      title: `Mismatch version`,
+      body: `
+tag: \`${tag}\`
+CURRENT_VERSION: \`${CURRENT_VERSION}\`
+`
+    })
+  }
+
+  if (compareVersions(tag, CURRENT_VERSION, '>')) {
+    await github.rest.issues.create({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      title: `python_templateの更新の適用 ${CURRENT_VERSION} → ${tag}`,
+      body: `
+更新は
+[ワークフローの実行](${context.payload.repository['html_url']}/actions/workflows/apply_python_template_updates.yml)
+or
+\`./scripts/apply_template_updates.sh\` を実行することで出来ます。
+
+[差分](https://github.com/besna-institute/python_template/compare/${CURRENT_VERSION}...${tag})
+[リリースノート](https://github.com/besna-institute/python_template/releases/tag/${tag})
+`
+    })
+  }
+}

--- a/.github/scripts/createPullRequest.js
+++ b/.github/scripts/createPullRequest.js
@@ -1,0 +1,23 @@
+const CURRENT_VERSION = require('./currentVersion.js')
+
+module.exports = async ({ github, context }, branch) => {
+  const tag = await github.rest.repos.listTags({
+    owner: 'besna-institute',
+    repo: 'python_template',
+  }).then(result => result.data[0].name)
+
+  await github.rest.pulls.create({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    head: branch,
+    base: context.ref,
+    title: `python_templateの更新の適用 ${CURRENT_VERSION} → ${tag}`,
+    body: `
+このPRは自動生成されたものです。
+
+権限の都合により、 \`.github/workflows\` 以下のファイルの変更は更新できないので確認してください。
+[差分](https://github.com/besna-institute/python_template/compare/${CURRENT_VERSION}...${tag})
+[リリースノート](https://github.com/besna-institute/python_template/releases/tag/${tag})
+`
+  })
+}

--- a/.github/scripts/currentVersion.js
+++ b/.github/scripts/currentVersion.js
@@ -1,0 +1,1 @@
+module.exports = "v4.4.0"

--- a/.github/workflows/apply_python_template_updates.yml
+++ b/.github/workflows/apply_python_template_updates.yml
@@ -1,0 +1,31 @@
+name: "Apply python_template updates"
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: "PR作成に使うブランチ名"
+        default: "apply-template-updates"
+        required: true
+      pathspec:
+        description: "変更適用対象のファイル。pathspecで指定する。" # https://git-scm.com/docs/gitignore#_pattern_format
+        default: "':/' ':!/src/models' ':!/src' ':!tests'"
+        required: true
+jobs:
+  create_pull_request:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          git checkout -b ${{ github.event.inputs.name }}
+          ./scripts/apply_template_updates.sh
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add ${{ github.event.inputs.pathspec }} ':!.github/workflows'
+          git commit -m 'Apply python_template updates'
+          git push --set-upstream origin apply-template-updates
+          git checkout .
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const script = require('./.github/scripts/createPullRequest.js')
+            await script({github, context}, '${{ github.event.inputs.name }}')

--- a/.github/workflows/check_for_updates.yml
+++ b/.github/workflows/check_for_updates.yml
@@ -1,5 +1,8 @@
 name: "Check for python_template updates"
-on: ["push"]
+on:
+  push:
+    branches:
+      - main
 jobs:
   check:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/check_for_updates.yml
+++ b/.github/workflows/check_for_updates.yml
@@ -1,0 +1,16 @@
+name: "Check for python_template updates"
+on: ["push"]
+jobs:
+  check:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install compare-versions
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const script = require('./.github/scripts/checkForUpdates.js')
+            await script({github, context})


### PR DESCRIPTION
- .github/workflows/apply_python_template_updates.yml は scripts/apply_template_updates.sh を実行してプルリクエストを自動で作成する。変更適用範囲はワークフロー実行時にpathspec（.gitignore等で使われる書式）で指定できる。
- .github/workflows/check_for_updates.yml は python_template の バージョンを確認して、最新バージョンじゃない場合はissue を追加する。
  - issue の追加については重複を防止する機構は今の所ない。（積極的にアップデートしてほしい）