### PR TITLE
PyLintのmagic-value-comparisonを無効化

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -145,7 +145,10 @@ disable=raw-checker-failed,
         misplaced-comparison-constant,
 
         # コメントアノテーションを使うことを推奨するため無効
-        fixme
+        fixme,
+
+        # 比較に置ける値については変数化を強制しないことにするため無効
+        magic-value-comparison
 
 
 # Enable the message, report, category or checker with the given id(s). You can
@@ -633,5 +636,5 @@ preferred-modules=
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when caught.
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception


### PR DESCRIPTION
# 変更目的
#98 で `magic-value-comparison` を無効化することにしたのでその対応

# 変更内容
 `magic-value-comparison` を無効化
その他、設定の微調整

<!-- 方法として考えたが結果として却下したもの、今後発生すると考えられるものなどがある場合は書く -->
<!-- # 考えたこと -->


<!-- 大局的な視点での不安要素や仕様として合意を取りたいものがある場合は書く -->
<!-- 特定のコードに対する、不安要素については行コメントでOK -->
<!-- # 特に確認してほしいこと -->


<!-- 問題として認識しているがこのPRではやらないことがある場合は書く -->
<!-- # やらないこと -->


<!-- レビューの参考になるものがある場合は書く -->
<!-- # 参考 -->

