### PR TITLE
openjdk-17-jreのインストールスクリプトの移動

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,6 @@
 # https://github.com/devcontainers/images/tree/main/src/python
 FROM mcr.microsoft.com/vscode/devcontainers/python:3.10
 RUN su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install 16 2>&1"
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
-  build-essential \
-  openjdk-17-jre \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
 
 # See https://github.com/hadolint/hadolint/releases
 ARG HADOLINT_VERSION="v2.12.0"

--- a/scripts/convert_open_api_to_dataclass.sh
+++ b/scripts/convert_open_api_to_dataclass.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+echo "Installing openjdk-17-jre..."
+sudo apt-get update
+sudo apt-get install -y openjdk-17-jre
+
+echo
+echo "Generating code from OpenAPI spec..."
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 cd "$PROJECT_ROOT/openapi-generator" || exit
 npm exec -y -- @openapitools/openapi-generator-cli generate -c openapi_generator.yaml
@@ -7,6 +13,9 @@ rm -fr "$PROJECT_ROOT/src/models/"*
 cp -r generated/src/models/* "$PROJECT_ROOT/src/models/"
 cp generated/src/util.py "$PROJECT_ROOT/src/models/_util.py"
 rm -fr generated
+
+echo
+echo "Formatting code..."
 cd "$PROJECT_ROOT" || exit
 python -m pyupgrade --py310-plus src/models/*.py
 python -m autoflake -i -r --remove-all-unused-imports src/models


### PR DESCRIPTION
# 変更目的
openjdk-17-jreのインストールが失敗する事象が度々発生するため。
openjdk-17-jreはOpenAPIのスキーマからコード生成する目的にのみ使われるのでDevContainerが起動されたときにインストールする必要はない。

# 変更内容
openjdk-17-jreのインストールをOpenAPIのコード生成のスクリプトに移動した。

<!-- 方法として考えたが結果として却下したもの、今後発生すると考えられるものなどがある場合は書く -->
<!-- # 考えたこと -->


<!-- 大局的な視点での不安要素や仕様として合意を取りたいものがある場合は書く -->
<!-- 特定のコードに対する、不安要素については行コメントでOK -->
<!-- # 特に確認してほしいこと -->


<!-- 問題として認識しているがこのPRではやらないことがある場合は書く -->
<!-- # やらないこと -->


<!-- レビューの参考になるものがある場合は書く -->
<!-- # 参考 -->

