### PR TITLE
リリース作成とバージョン管理手順ガイドの追加

### DIFF
--- a/.cursor/rules/release-guide.mdc
+++ b/.cursor/rules/release-guide.mdc
@@ -1,0 +1,57 @@
+---
+description: リリース作成、バージョン管理、GitHubリリース公開の手順ガイド
+globs: 
+alwaysApply: false
+---
+# リリース作成ガイド
+
+詳細な手順は [CONTRIBUTING.md](mdc:CONTRIBUTING.md) のリリース手順セクションを参照してください。
+
+## 重要な注意事項
+- リリースブランチのマージはGitHubのUIで行う
+- リリースノートはGitHubのUIで作成する
+
+## バージョンファイルの場所
+- テンプレートバージョン: `.github/scripts/currentVersion.js`
+
+## バージョニング規則
+[Semantic Versioning (semver)](mdc:https:/semver.org) を採用しています：
+
+### フォーマット: MAJOR.MINOR.PATCH
+
+バージョン番号は `v{MAJOR}.{MINOR}.{PATCH}` の形式で構成されます：
+
+#### 各数字の意味
+1. **MAJOR（メジャー）**: 最初の数字
+   - 破壊的変更（Breaking Changes）があるときにインクリメント
+   - 既存のAPIやインターフェースが変更され、後方互換性がない
+
+2. **MINOR（マイナー）**: 真ん中の数字
+   - 新機能追加時にインクリメント
+   - 後方互換性を保ちながら機能を追加
+
+3. **PATCH（パッチ）**: 最後の数字
+   - バグ修正時にインクリメント
+   - 後方互換性を保ちながらバグを修正
+
+#### リリースタイプと例
+- **パッチリリース** (v1.0.1): バグフィックスのみ
+- **マイナーリリース** (v1.1.0): 新機能追加、後方互換性あり
+- **メジャーリリース** (v2.0.0): 破壊的変更あり
+
+#### インクリメントのルール
+- MAJOR が上がるとき → MINOR と PATCH は 0 にリセット
+- MINOR が上がるとき → PATCH は 0 にリセット
+- PATCH が上がるとき → 他の数字は変更なし
+
+## リリースノート自動生成設定
+[.github/release.yml](mdc:.github/release.yml) で以下のラベル分類が設定済み：
+- ⚠ Breaking Changes (`breaking-change` ラベル)
+- 🎉 New Features (`enhancement` ラベル)  
+- 🛠 Bug Fixes (`bug` ラベル)
+- Other Changes (その他全て)
+
+## 関連ファイル
+- [CONTRIBUTING.md](mdc:CONTRIBUTING.md) - 詳細な手順
+- [.github/release.yml](mdc:.github/release.yml) - リリースノート設定
+- [.github/scripts/currentVersion.js](mdc:.github/scripts/currentVersion.js) - テンプレートバージョン


### PR DESCRIPTION
## 概要
リリース作成、バージョン管理、GitHubリリース公開の手順をまとめたガイドルールを追加しました。これにより開発チームがリリース作業を統一された手順で実行できるようになります。

## 変更内容
- `.cursor/rules/release-guide.mdc`を追加
  - Semantic Versioningのバージョニング規則を定義
  - MAJOR、MINOR、PATCHの使い分けを明記
  - リリースノートの自動生成設定について説明
  - バージョンファイルの場所を記載
  - CONTRIBUTING.mdへの参照を追加

## 影響範囲
- .cursorルールセット（新しいリリースガイドルールの追加）
- 開発者のリリース作業フロー（手順の標準化）

## 参考情報
### 関連ファイル
- [CONTRIBUTING.md](CONTRIBUTING.md) - 詳細なリリース手順
- [.github/release.yml](.github/release.yml) - リリースノート設定
- [.github/scripts/currentVersion.js](.github/scripts/currentVersion.js) - テンプレートバージョン

### バージョニング仕様
- [Semantic Versioning (semver)](https://semver.org)に準拠
- 破壊的変更、新機能追加、バグ修正の明確な分類

### 設計方針
- 既存のCONTRIBUTING.mdの詳細手順を補完する軽量なリファレンス
- Cursorエージェントが参照しやすい形式でのルール化