### PR TITLE
READMEにCursor起動時のPythonエラー対処法を追加

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -4,6 +4,7 @@ alstr
 Analyse
 analysed
 anydbm
+Anysphere
 apdisk
 astextplain
 autodocstring
@@ -20,6 +21,7 @@ cloudsdktool
 Connor
 cuda
 CUDNN
+cursorpyright
 deadsnakes
 devcontainers
 dmypy

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ pip freeze >> requirements.in
    - `schema.yaml`の構文が正しいか確認します。
    - Dockerコンテナ内で実行しているか確認します。
 
+4. **起動時にPythonに関するエラーが毎回出る**
+   - Cursor起動時に「In order to use Anysphere Python, `ms-python.vscode-pylance` must be uninstalled.」というエラーが毎回表示される場合があります。
+   - これは `ms-python.vscode-pylance` と `anysphere.cursorpyright` の拡張機能が両方インストールされていることが原因です。
+   - 解決方法：拡張機能 `anysphere.cursorpyright` をアンインストールしてください。（`anysphere.cursorpyright` は推奨する拡張機能には含まれていません）
+
 ## ログの書き方
 
 ### 基本的なログ出力


### PR DESCRIPTION
## 概要
READMEファイルのトラブルシューティングセクションに、Cursor起動時によく発生するPython拡張機能のエラーについての対処法を追加しました。これにより開発者がCursor使用時に遭遇する一般的な問題を素早く解決できるようになります。

## 変更内容
- READMEのよくある問題セクションに「起動時にPythonに関するエラーが毎回出る」項目を追加
- `ms-python.vscode-pylance`と`anysphere.cursorpyright`の競合問題とその解決方法を説明
- 関連する新しい単語（Anysphere、cursorpyright）をcspellプロジェクト辞書に追加

## 影響範囲
- READMEファイルのドキュメント内容
- cspellによるスペルチェック設定

## 参考情報
### 背景
Cursor IDEを使用する際に、Pythonの拡張機能同士が競合してエラーメッセージが毎回表示される問題が実際に発生したため、同様の問題に遭遇する他の開発者のためにドキュメントに追加しました。

### 解決方法
問題の原因となる`anysphere.cursorpyright`拡張機能をアンインストールすることで解決できることを確認しています。